### PR TITLE
Added fallback for --version when built from source

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,8 @@ var (
 
 func main() {
 
+	// Fix for #13, to provide a fallback version for plugin developers
+	// In general it's recommended to use the official builds.
 	if version == "" {
 		version = "BUILT_FROM_SOURCE"
 	}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,11 @@ var (
 )
 
 func main() {
+
+	if version == "" {
+		version = "BUILT_FROM_SOURCE"
+	}
+
 	app := cli.NewApp()
 	app.EnableBashCompletion = true
 	app.Version = version


### PR DESCRIPTION
This fixes #13 

```
➜  kombustion git:(ok/issue-13) ✗ ./kombustion -v
kombustion version BUILT_FROM_SOURCE
```