### PR TITLE
 Add flag to allow arbitrary loading of a plugin file for developing a plugin against core

### DIFF
--- a/internal/cloudformation/template.go
+++ b/internal/cloudformation/template.go
@@ -115,15 +115,9 @@ func GenerateYamlStack(params GenerateParams) (out YamlCloudformation, err error
 		return
 	}
 
-	// handle environment variables and custom params
-	envMap := ResolveEnvironment(params.EnvFile, params.Env)
-	for k, v := range params.ParamMap {
-		envMap[k] = v
-	}
-
 	//preprocess - template in the environment variables and custom params
 	buf := new(bytes.Buffer)
-	if err = executeTemplate(buf, configData, envMap); err != nil {
+	if err = executeTemplate(buf, configData, params.ParamMap); err != nil {
 		log.WithFields(log.Fields{
 			"template": configPath,
 		}).Error("Error executing config template")

--- a/internal/plugins/add.go
+++ b/internal/plugins/add.go
@@ -27,6 +27,10 @@ func AddPluginsToManifest(manifest *manifestType.Manifest, pluginLocations []str
 
 	// Get the lockFile
 	lockFile, err := lock.FindAndLoadLock()
+	if err != nil {
+		printer.Error(err, config.ErrorHelpInfo, "")
+		return manifest, err
+	}
 
 	// Add all the plugins to the manifest and lockfile
 	manifest, lockFile, err = addPluginsToManifestAndLock(manifest, lockFile, pluginLocations)
@@ -66,12 +70,14 @@ func addPluginsToManifestAndLock(
 		if err != nil {
 			return manifest, lockFile, err
 		}
+
 		if manifest.Plugins == nil {
 			manifest.Plugins = make(map[string]manifestType.Plugin)
 		}
 		if lockFile.Plugins == nil {
 			lockFile.Plugins = make(map[string]lock.Plugin)
 		}
+
 		manifest.Plugins[fmt.Sprintf("%s@%s", plugin.Name, plugin.Version)] = plugin
 		lockFile.Plugins[fmt.Sprintf("%s@%s", plugin.Name, plugin.Version)] = pluginLock
 	}

--- a/internal/plugins/extract.go
+++ b/internal/plugins/extract.go
@@ -1,0 +1,116 @@
+package plugins
+
+import (
+	"fmt"
+
+	printer "github.com/KablamoOSS/go-cli-printer"
+	kombustionTypes "github.com/KablamoOSS/kombustion/types"
+)
+
+// ExtractResourcesFromPlugins and ensure there are no clashes for plugin resource names
+func ExtractResourcesFromPlugins(
+	loadedPlugins []*PluginLoaded,
+	resources *map[string]kombustionTypes.ParserFunc,
+) {
+	for _, plugin := range loadedPlugins {
+		if *plugin.Resources != nil {
+			for key, parserFunc := range *plugin.Resources {
+				pluginKey := fmt.Sprintf("%s::%s", plugin.InternalConfig.Prefix, key)
+				if _, ok := (*resources)[pluginKey]; ok == false { // Check for duplicates
+					printer.Fatal(
+						fmt.Errorf("Plugin `%s` tried to load resource `%s` but it already exists", plugin.Config.Name, pluginKey),
+						fmt.Sprintf(
+							"You can add a `prefix` to this plugin in kombustion.yaml to resolve this.",
+						),
+						"",
+					)
+				} else {
+					wrappedParserFunc := func(
+						ctx map[string]interface{},
+						name string, data string,
+					) (
+						kombustionTypes.TemplateObject,
+						error,
+					) {
+						return loadResource(parserFunc(ctx, name, data))
+					}
+					(*resources)[pluginKey] = wrappedParserFunc
+				}
+			}
+		}
+	}
+	return
+}
+
+// ExtractMappingsFromPlugins and ensure there are no clashes for plugin resource names
+func ExtractMappingsFromPlugins(
+	loadedPlugins []*PluginLoaded,
+	mappings *map[string]kombustionTypes.ParserFunc,
+) {
+	for _, plugin := range loadedPlugins {
+		if *plugin.Mappings != nil {
+			for key, parserFunc := range *plugin.Mappings {
+				pluginKey := fmt.Sprintf("%s::%s", plugin.InternalConfig.Prefix, key)
+				if _, ok := (*mappings)[pluginKey]; ok { // Check for duplicates
+					printer.Fatal(
+						fmt.Errorf("Plugin `%s` tried to load mapping `%s` but it already exists", plugin.Config.Name, pluginKey),
+						fmt.Sprintf(
+							"You can add a `prefix` to this plugin in kombustion.yaml to resolve this.",
+						),
+						"",
+					)
+				} else {
+					wrappedParserFunc := func(
+						ctx map[string]interface{},
+						name string, data string,
+					) (
+						kombustionTypes.TemplateObject,
+						error,
+					) {
+						return loadResource(parserFunc(ctx, name, data))
+					}
+					(*mappings)[pluginKey] = wrappedParserFunc
+				}
+			}
+		}
+	}
+
+	return
+}
+
+// ExtractOutputsFromPlugins and ensure there are no clashes for plugin resource names
+func ExtractOutputsFromPlugins(
+	loadedPlugins []*PluginLoaded,
+	outputs *map[string]kombustionTypes.ParserFunc,
+) {
+	for _, plugin := range loadedPlugins {
+		if *plugin.Outputs != nil {
+			for key, parserFunc := range *plugin.Outputs {
+				pluginKey := fmt.Sprintf("%s::%s", plugin.InternalConfig.Prefix, key)
+				if _, ok := (*outputs)[pluginKey]; ok { // Check for duplicates
+
+					printer.Fatal(
+						fmt.Errorf("Plugin `%s` tried to load output `%s` but it already exists", plugin.Config.Name, pluginKey),
+						fmt.Sprintf(
+							"You can add a `prefix` to this plugin in kombustion.yaml to resolve this.",
+						),
+						"",
+					)
+				} else {
+					wrappedParserFunc := func(
+						ctx map[string]interface{},
+						name string, data string,
+					) (
+						kombustionTypes.TemplateObject,
+						error,
+					) {
+						return loadResource(parserFunc(ctx, name, data))
+					}
+					(*outputs)[pluginKey] = wrappedParserFunc
+				}
+			}
+		}
+	}
+
+	return
+}

--- a/internal/plugins/extract.go
+++ b/internal/plugins/extract.go
@@ -16,7 +16,7 @@ func ExtractResourcesFromPlugins(
 		if *plugin.Resources != nil {
 			for key, parserFunc := range *plugin.Resources {
 				pluginKey := fmt.Sprintf("%s::%s", plugin.InternalConfig.Prefix, key)
-				if _, ok := (*resources)[pluginKey]; ok == false { // Check for duplicates
+				if _, ok := (*resources)[pluginKey]; ok { // Check for duplicates
 					printer.Fatal(
 						fmt.Errorf("Plugin `%s` tried to load resource `%s` but it already exists", plugin.Config.Name, pluginKey),
 						fmt.Sprintf(

--- a/internal/plugins/load.go
+++ b/internal/plugins/load.go
@@ -6,8 +6,6 @@ import (
 	"plugin"
 	"runtime"
 
-	log "github.com/sirupsen/logrus"
-
 	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/internal/manifest"
 	"github.com/KablamoOSS/kombustion/internal/plugins/lock"
@@ -159,8 +157,12 @@ func configIsValid(config pluginTypes.Config, pluginName string, pluginVersion s
 	foundIssue := false
 	// TODO: improve these error messages, and provide links to the docs for plugin devs
 	if config.Name == "" {
-		// err
-		log.Fatal(fmt.Sprintf("%s did not supply a name, this plugin cannot be loaded", config.Name))
+		printer.Fatal(
+			fmt.Errorf("Plugin `%s` did not supply a name, this plugin cannot be loaded", pluginName),
+			"Try your command again, but if it fails file an issue with the plugin author.",
+			"",
+		)
+
 		foundIssue = true
 	}
 	// } else if config.Name != pluginName {
@@ -170,13 +172,23 @@ func configIsValid(config pluginTypes.Config, pluginName string, pluginVersion s
 	// }
 
 	if config.Prefix == "" {
-		log.Fatal(fmt.Sprintf("%s did not supply a prefix, this plugin cannot be loaded", config.Name))
+		printer.Fatal(
+			fmt.Errorf("Plugin `%s` did not supply a prefix, this plugin cannot be loaded", pluginName),
+			"Try your command again, but if it fails file an issue with the plugin author.",
+			"",
+		)
 		foundIssue = true
 	}
 
 	if config.RequiresAWSSession != requiresAWSSession {
 		// Warn about the need to add the config val to the manifest file
 		// foundIssue = true
+		printer.Fatal(
+			fmt.Errorf("Plugin `%s` requires an AWS session, has not been allowed one", pluginName),
+			fmt.Sprintf("Add `role: RoleName` to `kombustion.yaml` under `%s` to allow this plugin to assume that role.\n Reason for access: %s", pluginName, config.RequiresAWSSessionReason),
+			"",
+		)
+
 	}
 	if foundIssue == false {
 		ok = true

--- a/internal/plugins/load.go
+++ b/internal/plugins/load.go
@@ -25,7 +25,7 @@ func LoadPlugins(manifestFile *manifest.Manifest, lockFile *lock.Lock) (loadedPl
 						runtime.GOARCH == resolved.Architecture {
 						loadedPlugins = append(
 							loadedPlugins,
-							loadPlugin(manifestPlugin, plugin.Name, plugin.Version, resolved.PathOnDisk),
+							loadPlugin(manifestPlugin, plugin.Name, plugin.Version, resolved.PathOnDisk, false),
 						)
 					}
 				}
@@ -44,11 +44,26 @@ func LoadPlugins(manifestFile *manifest.Manifest, lockFile *lock.Lock) (loadedPl
 	return
 }
 
+// LoadDevPlugin loads an arbitrary plugin for plugin developers, to ease plugin development.
+// Only works with a kombustion binary that was built from source
+func LoadDevPlugin(
+	pluginPath string,
+) *PluginLoaded {
+	return loadPlugin(
+		manifest.Plugin{},
+		"dev-loaded-plugin",
+		"DEV",
+		pluginPath,
+		true,
+	)
+}
+
 func loadPlugin(
 	manifestPlugin manifest.Plugin,
 	pluginName string,
 	pluginVersion string,
 	pluginPath string,
+	isDevPlugin bool,
 ) *PluginLoaded {
 
 	loadedPlugin := PluginLoaded{}

--- a/internal/plugins/load.go
+++ b/internal/plugins/load.go
@@ -8,29 +8,14 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/internal/manifest"
 	"github.com/KablamoOSS/kombustion/internal/plugins/lock"
 	pluginTypes "github.com/KablamoOSS/kombustion/pkg/plugins/api/types"
-	kombustionTypes "github.com/KablamoOSS/kombustion/types"
 )
 
-// LoadPlugins for the project
-func LoadPlugins() (resources, outputs, mappings map[string]kombustionTypes.ParserFunc) {
-	resources, outputs, mappings =
-		make(map[string]kombustionTypes.ParserFunc),
-		make(map[string]kombustionTypes.ParserFunc),
-		make(map[string]kombustionTypes.ParserFunc)
-
-	lockFile, err := lock.FindAndLoadLock()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	manifestFile := manifest.FindAndLoadManifest()
-	if err != nil {
-		log.Fatal(err)
-	}
-
+// LoadPlugins from a manifest and lockfile
+func LoadPlugins(manifestFile *manifest.Manifest, lockFile *lock.Lock) (loadedPlugins []*PluginLoaded) {
 	// Load all plugins the manifest
 	for _, manifestPlugin := range manifestFile.Plugins {
 		for _, plugin := range lockFile.Plugins {
@@ -40,37 +25,61 @@ func LoadPlugins() (resources, outputs, mappings map[string]kombustionTypes.Pars
 					// Find the right plugin for the current OS/Arch
 					if runtime.GOOS == resolved.OperatingSystem &&
 						runtime.GOARCH == resolved.Architecture {
-						loadPlugin(manifestPlugin, plugin.Name, plugin.Version, resolved.PathOnDisk, resources, outputs, mappings)
+						loadedPlugins = append(
+							loadedPlugins,
+							loadPlugin(manifestPlugin, plugin.Name, plugin.Version, resolved.PathOnDisk),
+						)
 					}
 				}
 			} else {
-				log.Fatal(fmt.Sprintf("Plugin %s is not installed, but is included in kombustion.yaml. Run `kombustion install` to fix.", manifestPlugin.Name))
+				printer.Fatal(
+					fmt.Errorf("Plugin `%s` is not installed, but is included in kombustion.yaml", manifestPlugin.Name),
+					fmt.Sprintf(
+						"Run `kombustion install` to fix.",
+					),
+					"",
+				)
 			}
 		}
 	}
-	fmt.Println(resources)
-	return resources, outputs, mappings
+
+	return
 }
 
-func loadPlugin(manifestPlugin manifest.Plugin, pluginName string, pluginVersion string, pluginPath string, resources, outputs, mappings map[string]kombustionTypes.ParserFunc) {
-	resources, outputs, mappings =
-		make(map[string]kombustionTypes.ParserFunc),
-		make(map[string]kombustionTypes.ParserFunc),
-		make(map[string]kombustionTypes.ParserFunc)
+func loadPlugin(
+	manifestPlugin manifest.Plugin,
+	pluginName string,
+	pluginVersion string,
+	pluginPath string,
+) *PluginLoaded {
 
-		// TODO: Make the help messages for users much friendlier
+	loadedPlugin := PluginLoaded{}
+
+	// TODO: Make the help messages for users much friendlier
 	if !pluginExists(pluginPath) {
-		fmt.Fprintf(os.Stderr, "error: invalid plugin file: %s\n", pluginPath)
-		os.Exit(1)
+		printer.Fatal(
+			fmt.Errorf("Plugin `%s` is not installed, but is included in kombustion.lock", manifestPlugin.Name),
+			fmt.Sprintf(
+				"Run `kombustion install` to fix.",
+			),
+			"",
+		)
 	}
+
+	loadedPlugin.InternalConfig.PathOnDisk = pluginPath
 
 	// TODO: Check the hash of the plugin to load matches the lockfile
 
-	// open the plug-in file, causing its package init function to run,
-	// thereby registering the module
+	// Open the plugin
 	p, err := plugin.Open(pluginPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: failed to load plugin: %v\n", err)
+		printer.Fatal(
+			fmt.Errorf("Plugin `%s` could not be loaded, this is likely an issue with the plugin", manifestPlugin.Name),
+			fmt.Sprintf(
+				"Try your command again, but if it fails file an issue with the plugin author.",
+			),
+			"",
+		)
 	}
 
 	// Config
@@ -78,44 +87,38 @@ func loadPlugin(manifestPlugin manifest.Plugin, pluginName string, pluginVersion
 	configFunc := RegisterConstructor.(func() []byte)
 	config, err := loadConfig(configFunc())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: failed to load config for plugin: %v\n", err)
+		printer.Fatal(
+			fmt.Errorf("Plugin `%s` does not have a valid config", pluginName),
+			"Try your command again, but if it fails file an issue with the plugin author.",
+			"",
+		)
 	}
-	fmt.Println(config)
 
 	if configIsValid(config, pluginName, pluginVersion, false) == false {
-		log.Fatal(fmt.Sprintf("Unable to load plugin: %s", pluginName))
+		printer.Fatal(
+			fmt.Errorf("Plugin `%s` does not have a valid config", pluginName),
+			"Contact the plugin author.",
+			"",
+		)
 	}
 
-	prefix := config.Prefix
+	loadedPlugin.Config = config
+
+	loadedPlugin.InternalConfig.Prefix = config.Prefix
 
 	if manifestPlugin.Alias != "" {
-		prefix = manifestPlugin.Alias
+		loadedPlugin.InternalConfig.Prefix = manifestPlugin.Alias
 	}
 
 	// [ Resources ]----------------------------------------------------------------------------------
 
 	resourcesConstructor, _ := p.Lookup("Resources")
 	if resourcesConstructor != nil {
-
-		resourcesFuncs := *resourcesConstructor.(*map[string]func(
+		loadedPlugin.Resources = resourcesConstructor.(*map[string]func(
 			ctx map[string]interface{},
 			name string,
 			data string,
 		) []byte)
-
-		for key, parserFunc := range resourcesFuncs {
-			pluginKey := fmt.Sprintf("%s::%s", prefix, key)
-			if _, ok := resources[pluginKey]; ok { // Check for duplicates
-				log.WithFields(log.Fields{
-					"resource": pluginKey,
-				}).Warn("duplicate resource definition for resource")
-			} else {
-				wrappedParserFunc := func(ctx map[string]interface{}, name string, data string) (kombustionTypes.TemplateObject, error) {
-					return loadResource(parserFunc(ctx, name, data))
-				}
-				resources[pluginKey] = wrappedParserFunc
-			}
-		}
 	}
 
 	// [ Mapping ]------------------------------------------------------------------------------------
@@ -123,54 +126,25 @@ func loadPlugin(manifestPlugin manifest.Plugin, pluginName string, pluginVersion
 	mappingsConstructor, _ := p.Lookup("Mappings")
 	if mappingsConstructor != nil {
 
-		mappingsFuncs := *mappingsConstructor.(*map[string]func(
+		loadedPlugin.Mappings = mappingsConstructor.(*map[string]func(
 			ctx map[string]interface{},
 			name string,
 			data string,
 		) []byte)
-
-		for key, parserFunc := range mappingsFuncs {
-			pluginKey := fmt.Sprintf("%s::%s", prefix, key)
-			if _, ok := mappings[pluginKey]; ok { // Check for duplicates
-				log.WithFields(log.Fields{
-					"resource": pluginKey,
-				}).Warn("duplicate resource definition for mapping")
-			} else {
-				wrappedParserFunc := func(ctx map[string]interface{}, name string, data string) (kombustionTypes.TemplateObject, error) {
-					return loadResource(parserFunc(ctx, name, data))
-				}
-				mappings[pluginKey] = wrappedParserFunc
-			}
-		}
 	}
 
 	// [ Outputs ]------------------------------------------------------------------------------------
 
-	outputsConstructor, _ := p.Lookup("Mapping")
+	outputsConstructor, _ := p.Lookup("Outputs")
 	if outputsConstructor != nil {
-
-		outputsFuncs := *outputsConstructor.(*map[string]func(
+		loadedPlugin.Outputs = outputsConstructor.(*map[string]func(
 			ctx map[string]interface{},
 			name string,
 			data string,
 		) []byte)
-
-		for key, parserFunc := range outputsFuncs {
-			pluginKey := fmt.Sprintf("%s::%s", prefix, key)
-			if _, ok := outputs[pluginKey]; ok { // Check for duplicates
-				log.WithFields(log.Fields{
-					"resource": key,
-				}).Warn("duplicate resource definition for output")
-			} else {
-				wrappedParserFunc := func(ctx map[string]interface{}, name string, data string) (kombustionTypes.TemplateObject, error) {
-					return loadResource(parserFunc(ctx, name, data))
-				}
-				outputs[pluginKey] = wrappedParserFunc
-			}
-		}
 	}
 
-	return
+	return &loadedPlugin
 }
 
 // Helper function to ensure a plugin file exists before we attempt to load it

--- a/internal/plugins/lock/load.go
+++ b/internal/plugins/lock/load.go
@@ -2,20 +2,31 @@ package lock
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
+	printer "github.com/KablamoOSS/go-cli-printer"
+	"github.com/KablamoOSS/kombustion/config"
 	"github.com/KablamoOSS/yaml"
 )
 
 // FindAndLoadLock - Search the current directory for a Lock file, and load it
+// If no lock is found, return an empty Lock
 func FindAndLoadLock() (lock *Lock, err error) {
 	path, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
-		log.Fatal(err)
+		printer.Fatal(err, config.ErrorHelpInfo, "")
 	}
-	return findAndLoadLock(path)
+	lock, err = findAndLoadLock(path)
+	if err != nil {
+		printer.Fatal(err, config.ErrorHelpInfo, "")
+	}
+
+	if lock == nil {
+		lock = &Lock{}
+		lock.Plugins = make(map[string]Plugin)
+	}
+	return
 }
 
 // findAndLoadLock - Search the given directory for a Lock , and load it

--- a/internal/plugins/lock/write.go
+++ b/internal/plugins/lock/write.go
@@ -3,6 +3,8 @@ package lock
 import (
 	"io/ioutil"
 
+	printer "github.com/KablamoOSS/go-cli-printer"
+	"github.com/KablamoOSS/kombustion/config"
 	"github.com/KablamoOSS/yaml"
 )
 
@@ -18,7 +20,7 @@ func WriteLockToDisk(lockFile *Lock) error {
 	// Write the LockString
 	err = ioutil.WriteFile("kombustion.lock", lockString, 0644)
 	if err != nil {
-		return err
+		printer.Fatal(err, config.ErrorHelpInfo, "")
 	}
 	return nil
 }

--- a/internal/plugins/types.go
+++ b/internal/plugins/types.go
@@ -1,0 +1,32 @@
+package plugins
+
+import (
+	apiTypes "github.com/KablamoOSS/kombustion/pkg/plugins/api/types"
+)
+
+// PluginLoaded is a fully loaded plugin
+type PluginLoaded struct {
+	Resources *map[string]func(
+		ctx map[string]interface{},
+		name string,
+		data string,
+	) []byte
+
+	Outputs *map[string]func(
+		ctx map[string]interface{},
+		name string,
+		data string,
+	) []byte
+
+	Mappings *map[string]func(
+		ctx map[string]interface{},
+		name string,
+		data string,
+	) []byte
+
+	Config         apiTypes.Config
+	InternalConfig struct {
+		Prefix     string
+		PathOnDisk string
+	}
+}

--- a/internal/tasks/add.go
+++ b/internal/tasks/add.go
@@ -1,10 +1,9 @@
 package tasks
 
 import (
-	"log"
-
 	"github.com/KablamoOSS/go-cli-printer"
 
+	"github.com/KablamoOSS/kombustion/config"
 	"github.com/KablamoOSS/kombustion/internal/manifest"
 	"github.com/KablamoOSS/kombustion/internal/plugins"
 	"github.com/urfave/cli"
@@ -22,13 +21,13 @@ func AddPluginToManifest(c *cli.Context) error {
 	// Add them
 	_, err := plugins.AddPluginsToManifest(manifestFile, pluginNames)
 	if err != nil {
-		log.Fatal(err)
+		printer.Fatal(err, config.ErrorHelpInfo, "")
 	}
 
 	// Now install them
 	err = plugins.InstallPlugins()
 	if err != nil {
-		log.Fatal(err)
+		printer.Fatal(err, config.ErrorHelpInfo, "")
 	}
 	return nil
 }

--- a/internal/tasks/delete.go
+++ b/internal/tasks/delete.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation/tasks"
 	"github.com/urfave/cli"
 )
@@ -14,5 +15,8 @@ var DeleteFlags = []cli.Flag{
 }
 
 func Delete(c *cli.Context) {
+	printer.Step("Deleting stack")
+	printer.Progress("Kombusting")
+
 	tasks.DeleteStack(c.Args().Get(0), c.GlobalString("profile"), c.String("region"))
 }

--- a/internal/tasks/events.go
+++ b/internal/tasks/events.go
@@ -1,12 +1,16 @@
 package tasks
 
 import (
+	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation/tasks"
 	"github.com/urfave/cli"
 )
 
 // PrintEvents outputs the events of a stack
 func PrintEvents(c *cli.Context) {
+	printer.Step("Printing events")
+	printer.Progress("Kombusting")
+
 	cf := tasks.GetCloudformationClient(c.GlobalString("profile"), c.String("region"))
 	stackName := c.Args().Get(0)
 	tasks.PrintStackEvents(cf, stackName)

--- a/internal/tasks/flags.go
+++ b/internal/tasks/flags.go
@@ -10,7 +10,7 @@ var GlobalFlags = []cli.Flag{
 	},
 	cli.StringSliceFlag{
 		Name:  "param, p",
-		Usage: "cloudformation parameters. eg. ( -p Env=dev -p BucketName=test )",
+		Usage: "cloudformation parameters `BucketName=test`",
 	},
 }
 
@@ -18,15 +18,14 @@ var GlobalFlags = []cli.Flag{
 var CloudFormationStackFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "region, r",
-		Usage: "region to deploy to",
+		Usage: "region to deploy to eg `us-east-1`",
 	},
 	cli.StringFlag{
 		Name:  "stack-name",
-		Usage: "stack name to deploy (defaults to ProjectName-Filename--Environment)",
+		Usage: "stack name to deploy [Default: ProjectName-Filename-Environment] eg `StackName-Environment`",
 	},
 	cli.StringFlag{
 		Name:  "environment, e",
-		Usage: "environment config to use from ./kombustion.yaml",
-		// Help:  "If you omit this, it will be derived based on the account the role is assumed from, provided that account is listed under an environment.",
+		Usage: "environment config to use from ./kombustion.yaml eg `production`",
 	},
 }

--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -1,8 +1,13 @@
 package tasks
 
 import (
+	"log"
+
 	"github.com/KablamoOSS/kombustion/internal/cloudformation"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation/tasks"
+	"github.com/KablamoOSS/kombustion/internal/manifest"
+	"github.com/KablamoOSS/kombustion/internal/plugins"
+	"github.com/KablamoOSS/kombustion/internal/plugins/lock"
 	"github.com/urfave/cli"
 )
 
@@ -26,11 +31,27 @@ func init() {
 func Generate(c *cli.Context) {
 	paramMap := cloudformation.GetParamMap(c)
 
+	lockFile, err := lock.FindAndLoadLock()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	manifestFile := manifest.FindAndLoadManifest()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// load all plugins
+	loadedPlugins := plugins.LoadPlugins(manifestFile, lockFile)
+
+	// if in devMode optionally load a devMode plugin
+
 	tasks.GenerateTemplate(cloudformation.GenerateParams{
 		Filename:           c.Args().Get(0),
 		EnvFile:            c.String("env-file"),
 		Env:                c.String("env"),
 		DisableBaseOutputs: c.Bool("no-base-outputs"),
 		ParamMap:           paramMap,
+		Plugins:            loadedPlugins,
 	})
 }

--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"fmt"
-	"log"
 
 	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation"
@@ -31,6 +30,8 @@ func init() {
 
 // Generate a template and save it to disk, without upserting it
 func Generate(c *cli.Context) {
+	printer.Step("Generating template")
+	printer.Progress("Kombusting")
 
 	fileName := c.Args().Get(0)
 	if fileName == "" {
@@ -47,12 +48,24 @@ func Generate(c *cli.Context) {
 
 	lockFile, err := lock.FindAndLoadLock()
 	if err != nil {
-		log.Fatal(err)
+		printer.Fatal(
+			err,
+			fmt.Sprintf(
+				"kombustion.lock may need to be rebuilt",
+			),
+			"",
+		)
 	}
 
 	manifestFile := manifest.FindAndLoadManifest()
 	if err != nil {
-		log.Fatal(err)
+		printer.Fatal(
+			err,
+			fmt.Sprintf(
+				"kombustion.yaml may need to be rebuilt",
+			),
+			"",
+		)
 	}
 
 	// load all plugins

--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -1,8 +1,10 @@
 package tasks
 
 import (
+	"fmt"
 	"log"
 
+	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation/tasks"
 	"github.com/KablamoOSS/kombustion/internal/manifest"
@@ -15,7 +17,7 @@ import (
 var GenerateFlags = []cli.Flag{
 	cli.StringSliceFlag{
 		Name:  "param, p",
-		Usage: "cloudformation parameters. eg. ( --param Env=dev --param BucketName=test )",
+		Usage: "cloudformation parameters. eg. `--param Env=dev --param BucketName=test`",
 	},
 	cli.BoolFlag{
 		Name:  "no-base-outputs, b",
@@ -29,6 +31,18 @@ func init() {
 
 // Generate a template and save it to disk, without upserting it
 func Generate(c *cli.Context) {
+
+	fileName := c.Args().Get(0)
+	if fileName == "" {
+		printer.Fatal(
+			fmt.Errorf("Can't generate file, no source template provided"),
+			fmt.Sprintf(
+				"Add the path to the source template file you want to generate like: `kombustion generate template.yaml`.",
+			),
+			"",
+		)
+	}
+
 	paramMap := cloudformation.GetParamMap(c)
 
 	lockFile, err := lock.FindAndLoadLock()
@@ -45,10 +59,15 @@ func Generate(c *cli.Context) {
 	loadedPlugins := plugins.LoadPlugins(manifestFile, lockFile)
 
 	// if in devMode optionally load a devMode plugin
+	devPluginPath := c.GlobalString("load-plugin")
+
+	if devPluginPath != "" {
+		devPluginLoaded := plugins.LoadDevPlugin(devPluginPath)
+		loadedPlugins = append(loadedPlugins, devPluginLoaded)
+	}
 
 	tasks.GenerateTemplate(cloudformation.GenerateParams{
-		Filename:           c.Args().Get(0),
-		EnvFile:            c.String("env-file"),
+		Filename:           fileName,
 		Env:                c.String("env"),
 		DisableBaseOutputs: c.Bool("no-base-outputs"),
 		ParamMap:           paramMap,

--- a/internal/tasks/install.go
+++ b/internal/tasks/install.go
@@ -13,6 +13,9 @@ import (
 // Which is to say, ensure the manifest and lock file agree with the state of the plugins
 // and then ensure the lock file agrees with the disk on the state of the plugins
 func InstallPlugins(c *cli.Context) {
+	printer.Step("Installing plugins")
+	printer.Progress("Kombusting")
+
 	err := plugins.InstallPlugins()
 	if err != nil {
 		printer.Fatal(err, fmt.Sprintf("%s\n%s", "Instaling plugins failed. Try again.", config.ErrorHelpInfo), "")

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -1,10 +1,15 @@
 package tasks
 
 import (
+	"fmt"
+	"log"
+
 	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation/tasks"
 	"github.com/KablamoOSS/kombustion/internal/manifest"
+	"github.com/KablamoOSS/kombustion/internal/plugins"
+	"github.com/KablamoOSS/kombustion/internal/plugins/lock"
 	"github.com/aws/aws-sdk-go/aws"
 	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/urfave/cli"
@@ -14,7 +19,7 @@ import (
 var UpsertFlags = []cli.Flag{
 	cli.StringSliceFlag{
 		Name:  "param, p",
-		Usage: "cloudformation parameters. eg. [ --param Env=dev --param BucketName=test ]",
+		Usage: "cloudformation parameters. eg `BucketName=test`",
 	},
 	cli.BoolFlag{
 		Name:  "no-base-outputs, b",
@@ -26,18 +31,49 @@ var UpsertFlags = []cli.Flag{
 	},
 	cli.StringSliceFlag{
 		Name:  "capability",
-		Usage: "set capabilities for the upsert, eg [ --capability CAPABILITY_IAM ]",
+		Usage: "set capabilities for the upsert eg `CAPABILITY_IAM`",
 	},
 }
 
 func init() {
-	UpsertFlags = append(CloudFormationStackFlags)
+	UpsertFlags = append(CloudFormationStackFlags, UpsertFlags...)
 }
 
 // Upsert a stack
 func Upsert(c *cli.Context) {
 	printer.Step("Upserting stack")
-	manifest := manifest.FindAndLoadManifest()
+
+	fileName := c.Args().Get(0)
+	if fileName == "" {
+		printer.Fatal(
+			fmt.Errorf("Can't upsert file, no source template provided"),
+			fmt.Sprintf(
+				"Add the path to the source template file you want to generate like: `kombustion upsert template.yaml`.",
+			),
+			"",
+		)
+	}
+
+	lockFile, err := lock.FindAndLoadLock()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	manifestFile := manifest.FindAndLoadManifest()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// load all plugins
+	loadedPlugins := plugins.LoadPlugins(manifestFile, lockFile)
+
+	// if in devMode optionally load a devMode plugin
+	devPluginPath := c.GlobalString("load-plugin")
+
+	if devPluginPath != "" {
+		devPluginLoaded := plugins.LoadDevPlugin(devPluginPath)
+		loadedPlugins = append(loadedPlugins, devPluginLoaded)
+	}
 
 	cfClient := tasks.GetCloudformationClient(
 		c.GlobalString("profile"),
@@ -48,11 +84,11 @@ func Upsert(c *cli.Context) {
 
 	// Template generation parameters
 	generateParams := cloudformation.GenerateParams{
-		Filename:           c.Args().Get(0),
-		EnvFile:            c.String("env-file"),
+		Filename:           fileName,
 		Env:                c.String("env"),
 		DisableBaseOutputs: c.Bool("no-base-outputs"),
 		ParamMap:           paramMap,
+		Plugins:            loadedPlugins,
 	}
 
 	capabilities := getCapabilities(c)
@@ -67,7 +103,7 @@ func Upsert(c *cli.Context) {
 	if len(c.String("url")) > 0 {
 		// TODO: We probably need to download the template to determine what params
 		// it needs, and filter the available params only to those
-		parameters = cloudformation.ResolveParametersS3(c, manifest)
+		parameters = cloudformation.ResolveParametersS3(c, manifestFile)
 
 		templateURL := c.String("url")
 
@@ -81,7 +117,7 @@ func Upsert(c *cli.Context) {
 	} else {
 
 		templateBody, cfYaml := tasks.GenerateYamlTemplate(generateParams)
-		parameters = cloudformation.ResolveParameters(c, cfYaml, manifest)
+		parameters = cloudformation.ResolveParameters(c, cfYaml, manifestFile)
 
 		tasks.UpsertStack(
 			templateBody,

--- a/main.go
+++ b/main.go
@@ -73,6 +73,16 @@ func main() {
 	// In general it's recommended to use the official builds.
 	if version == "" {
 		version = "BUILT_FROM_SOURCE"
+
+		devModeFlags := []cli.Flag{
+			cli.StringFlag{
+				Name:  "load-plugin",
+				Usage: "load arbitrary plugin --load-plugin path/to/plugin.so",
+			},
+		}
+
+		tasks.GlobalFlags = append(tasks.GlobalFlags, devModeFlags...)
+
 	}
 
 	kombustionLogo := chalk.Dim.TextStyle(`

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ import (
 	"os"
 
 	printer "github.com/KablamoOSS/go-cli-printer"
+	"github.com/KablamoOSS/kombustion/config"
 	"github.com/KablamoOSS/kombustion/internal/tasks"
 	log "github.com/sirupsen/logrus"
 	"github.com/ttacon/chalk"
@@ -77,7 +78,7 @@ func main() {
 		devModeFlags := []cli.Flag{
 			cli.StringFlag{
 				Name:  "load-plugin",
-				Usage: "load arbitrary plugin --load-plugin path/to/plugin.so",
+				Usage: "load arbitrary plugin `path/to/plugin.so`",
 			},
 		}
 
@@ -187,5 +188,9 @@ ISSUES:
 		},
 	}
 
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+
+	if err != nil {
+		printer.Fatal(err, config.ErrorHelpInfo, "")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -189,8 +189,14 @@ ISSUES:
 	}
 
 	err := app.Run(os.Args)
-
 	if err != nil {
+		if err.Error() == "flag provided but not defined: -load-plugin" {
+			printer.Fatal(
+				err,
+				"--load-plugin is only available when kombustion is built from source. See the link below for more information.",
+				"https://www.kombustion.io/plugins/developing",
+				)
+		}
 		printer.Fatal(err, config.ErrorHelpInfo, "")
 	}
 }

--- a/pkg/plugins/api/types/types.go
+++ b/pkg/plugins/api/types/types.go
@@ -6,7 +6,10 @@ type Config struct {
 	Version            string
 	Prefix             string
 	RequiresAWSSession bool
-	Help               Help
+	// This is printed to the screen if the user has not provided a role, explaining
+	// what the role is used for
+	RequiresAWSSessionReason string
+	Help                     Help
 }
 
 // Help - a set of available documentation fields


### PR DESCRIPTION
Fixes #48

Also contains some updated error messages, and a refactor of how plugins are loaded.

When core is built from source `go build` from inside `go/src/github.com/KablamoOSS/kombustion`, dev mode is enabled (so to speak) and a new flag `--load-plugin` is made available.

This allows plugin developers to quickly test builds of their plugins, while preventing arbitrary plugins from being loaded from mainline tagged releases.

`./kombustion --load-plugin ../kombustion-plugin-serverless/kombustion-plugin-serverless.so generate test.yaml`