### PR TITLE
fix resources getting dropped from output

### DIFF
--- a/internal/cloudformation/template.go
+++ b/internal/cloudformation/template.go
@@ -2,7 +2,6 @@ package cloudformation
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -341,19 +340,24 @@ func mergeResources(
 ) {
 	combinedResource = make(types.TemplateObject)
 
+	// The yaml round-trip here is because there may be problems with the
+	// msgpack round-trip from plugins. This is because we don't tag structs
+	// with `msgpack:FieldName,omitempty` (doing so would also require plugin
+	// writers to do the same). The yaml round-trip here ensures that
+	// empty/null values are handled correctly.
 	for k, v := range configResources {
-		if obj, err := json.Marshal(v); err == nil {
+		if obj, err := yaml.Marshal(v); err == nil {
 			var tempCfResource types.CfResource
-			if err = json.Unmarshal(obj, &tempCfResource); err == nil {
+			if err = yaml.Unmarshal(obj, &tempCfResource); err == nil {
 				combinedResource[k] = tempCfResource
 			}
 		}
 	}
 
 	for k, v := range baseResources {
-		if obj, err := json.Marshal(v); err == nil {
+		if obj, err := yaml.Marshal(v); err == nil {
 			var tempCfResource types.CfResource
-			if err = json.Unmarshal(obj, &tempCfResource); err == nil {
+			if err = yaml.Unmarshal(obj, &tempCfResource); err == nil {
 				combinedResource[k] = tempCfResource
 			}
 		}

--- a/pkg/plugins/api/marshalling.go
+++ b/pkg/plugins/api/marshalling.go
@@ -58,11 +58,10 @@ func cleanResult(objects kombustionTypes.TemplateObject) (result kombustionTypes
 	result = make(kombustionTypes.TemplateObject)
 
 	for k, v := range objects {
-		// We need to check the value is not empty, to prevent a nil pointer in the yaml.Marshall
+		// We need to check the value is not empty, to prevent a nil pointer in the yaml.Marshal
 		// it will be empty when the user leaves a key blank in their template
 		if v != nil {
 			obj, err := yaml.Marshal(v)
-			// fmt.Println(err)
 			if err == nil {
 				var tempObject kombustionTypes.TemplateObject
 				err = yaml.Unmarshal(obj, &tempObject)


### PR DESCRIPTION
Resources were getting dropped from the compiled output due to errors in
the json round-trip meant to cleanup empty/null values. Since our
structs are tagged with `yaml:` we should use yaml to round-trip.