### PR TITLE
obey manifest GenerateDefaultOutputs setting

### DIFF
--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -76,7 +76,7 @@ func Generate(c *cli.Context) {
 		Directory:   c.String("output-directory"),
 		WriteParams: c.Bool("write-parameters"),
 		Env:         c.String("env"),
-		GenerateDefaultOutputs: c.Bool("generate-default-outputs"),
+		GenerateDefaultOutputs: c.Bool("generate-default-outputs") || manifestFile.GenerateDefaultOutputs,
 		ParamMap:               paramMap,
 		Plugins:                loadedPlugins,
 	})

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -90,7 +90,7 @@ func Upsert(c *cli.Context) {
 	generateParams := cloudformation.GenerateParams{
 		Filename: fileName,
 		Env:      environment,
-		GenerateDefaultOutputs: c.Bool("generate-default-outputs"),
+		GenerateDefaultOutputs: c.Bool("generate-default-outputs") || manifestFile.GenerateDefaultOutputs,
 		ParamMap:               paramMap,
 		Plugins:                loadedPlugins,
 	}


### PR DESCRIPTION
Fixes #71 

The `--generate-default-outputs` flag works as expected per my testing, but the manifest setting is being ignored.