### PR TITLE
first pass to allow adding cfn tags

### DIFF
--- a/internal/cloudformation/parameters.go
+++ b/internal/cloudformation/parameters.go
@@ -33,6 +33,10 @@ func ResolveParameters(
 
 	env := resolveEnvironmentParameters(manifestFile, c.String("environment"))
 
+	if env == nil {
+		env = make(map[string]string)
+	}
+
 	// override envFile values with optional --param values
 	params := GetParamMap(c)
 	for key, value := range params {

--- a/internal/cloudformation/tasks/upsert.go
+++ b/internal/cloudformation/tasks/upsert.go
@@ -18,10 +18,16 @@ func UpsertStack(
 	capabilities []*string,
 	stackName string,
 	cf *awsCF.CloudFormation,
+	tags map[string]string,
 ) {
 
 	var err error
 	var action string
+
+	cfTags := make([]*awsCF.Tag, 0)
+	for key, value := range tags {
+		cfTags = append(cfTags, &awsCF.Tag{Key: &key, Value: &value})
+	}
 
 	// use template from file
 	_, err = cf.DescribeStacks(&awsCF.DescribeStacksInput{StackName: aws.String(stackName)})
@@ -33,6 +39,7 @@ func UpsertStack(
 			TemplateBody: aws.String(string(templateBody)),
 			Parameters:   parameters,
 			Capabilities: capabilities,
+			Tags:         cfTags,
 		})
 	} else {
 		action = "Creating"
@@ -42,6 +49,7 @@ func UpsertStack(
 			TemplateBody: aws.String(string(templateBody)),
 			Parameters:   parameters,
 			Capabilities: capabilities,
+			Tags:         cfTags,
 		})
 	}
 	checkError(err)
@@ -56,10 +64,16 @@ func UpsertStackViaS3(
 	capabilities []*string,
 	stackName string,
 	cf *awsCF.CloudFormation,
+	tags map[string]string,
 ) {
 
 	var err error
 	var action string
+
+	cfTags := make([]*awsCF.Tag, 0)
+	for key, value := range tags {
+		cfTags = append(cfTags, &awsCF.Tag{Key: &key, Value: &value})
+	}
 
 	// use cf template url
 	_, err = cf.DescribeStacks(&awsCF.DescribeStacksInput{StackName: aws.String(stackName)})
@@ -72,6 +86,7 @@ func UpsertStackViaS3(
 			TemplateURL:  aws.String(templateURL),
 			Parameters:   parameters,
 			Capabilities: capabilities,
+			Tags:         cfTags,
 		})
 	} else { //create
 		action = "Creating"
@@ -81,6 +96,7 @@ func UpsertStackViaS3(
 			TemplateURL:  aws.String(templateURL),
 			Parameters:   parameters,
 			Capabilities: capabilities,
+			Tags:         cfTags,
 		})
 	}
 	checkError(err)

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -22,6 +22,9 @@ type Manifest struct {
 	// A flag to indicate if default exports should be added to stacks in this project
 	// this defaults to false
 	GenerateDefaultOutputs bool `yaml:"GenerateDefaultOutputs"`
+
+	// A set of default tags that will be applied to created stacks
+	Tags map[string]string `yaml:"Tags"`
 }
 
 // Plugin specification inside the manifest

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -116,6 +116,7 @@ func Upsert(c *cli.Context) {
 			capabilities,
 			stackName,
 			cfClient,
+			manifestFile.Tags,
 		)
 	} else {
 
@@ -128,6 +129,7 @@ func Upsert(c *cli.Context) {
 			capabilities,
 			stackName,
 			cfClient,
+			manifestFile.Tags,
 		)
 	}
 }


### PR DESCRIPTION
First pass limited to a global setting in kombustion.yaml that applies to all created stacks. Per environment tags in kombustion.yaml and cli flags to come in followup PRs.