### PR TITLE
Opt-in flag to confirm changes before applying

### DIFF
--- a/internal/cloudformation/tasks/upsert.go
+++ b/internal/cloudformation/tasks/upsert.go
@@ -102,20 +102,21 @@ func upsertStack(
 	printer.SubStep("Changes to be applied:", 1, true, true)
 	for _, change := range changeSet.Changes {
 		resChange := change.ResourceChange
-		// TODO: ResourceChange has a .Replacement field to indicate whether a
-		// Modify action will update in place or recreate the resource. We
-		// should probably stitch that into the output.
-		printer.SubStep(
-			fmt.Sprintf(
-				"%s %s %s",
-				*resChange.Action,
-				*resChange.LogicalResourceId,
-				*resChange.ResourceType,
-			),
-			1,
-			true,
-			true,
+
+		line := fmt.Sprintf(
+			"%6s %s %s",
+			*resChange.Action,
+			*resChange.ResourceType,
+			*resChange.LogicalResourceId,
 		)
+		if *resChange.Action == "Modify" {
+			line = fmt.Sprintf(
+				"%s (Replacement: %s)",
+				line,
+				*resChange.Replacement,
+			)
+		}
+		printer.SubStep(line, 1, true, true)
 	}
 
 	if confirm {

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -40,6 +40,10 @@ var UpsertFlags = []cli.Flag{
 		Name:  "capability",
 		Usage: "set capabilities for the upsert eg `CAPABILITY_IAM`",
 	},
+	cli.BoolFlag{
+		Name:  "confirm",
+		Usage: "Manually confirm required changes before applying",
+	},
 }
 
 func init() {
@@ -145,6 +149,7 @@ func Upsert(c *cli.Context) {
 			stackName,
 			cfClient,
 			tags,
+			c.Bool("confirm"),
 		)
 	} else {
 
@@ -158,6 +163,7 @@ func Upsert(c *cli.Context) {
 			stackName,
 			cfClient,
 			tags,
+			c.Bool("confirm"),
 		)
 	}
 }


### PR DESCRIPTION
Adds an opt-in --confirm flag, which when present will prompt the user to confirm the change set before applying.