### PR TITLE
check aws account against ids in yaml

### DIFF
--- a/internal/cloudformation/tasks/delete.go
+++ b/internal/cloudformation/tasks/delete.go
@@ -2,17 +2,16 @@ package tasks
 
 import (
 	"fmt"
+	printer "github.com/KablamoOSS/go-cli-printer"
 	"os"
 	"time"
-	printer "github.com/KablamoOSS/go-cli-printer"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
 // DeleteStack removes a cloudformation stack
-func DeleteStack(stackName, profile, region string) {
-	cf := GetCloudformationClient(profile, region)
+func DeleteStack(cf *cloudformation.CloudFormation, stackName, region string) {
 	printer.Step(fmt.Sprintf("Delete Stack %s:", stackName))
 
 	//See if the stack exists to begin with

--- a/internal/manifest/environment.go
+++ b/internal/manifest/environment.go
@@ -1,0 +1,15 @@
+package manifest
+
+func (env *Environment) IsWhitelistedAccount(acctID string) bool {
+	if len(env.AccountIDs) == 0 {
+		// If no account IDs are specified, assume allow all
+		return true
+	}
+
+	for _, id := range env.AccountIDs {
+		if acctID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tasks/delete.go
+++ b/internal/tasks/delete.go
@@ -46,9 +46,20 @@ func Delete(c *cli.Context) {
 		}
 	}
 
+	acctID, cf := tasks.GetCloudformationClient(c.GlobalString("profile"), region)
+	if env, ok := manifestFile.Environments[environment]; ok {
+		if !env.IsWhitelistedAccount(acctID) {
+			printer.Fatal(
+				fmt.Errorf("Account %s is not allowed for environment %s", acctID, environment),
+				"Use whitelisted account, or add account to environment accounts in kombustion.yaml",
+				"",
+			)
+		}
+	}
+
 	tasks.DeleteStack(
+		cf,
 		stackName,
-		c.GlobalString("profile"),
 		region,
 	)
 }

--- a/internal/tasks/events.go
+++ b/internal/tasks/events.go
@@ -24,7 +24,7 @@ func PrintEvents(c *cli.Context) {
 		}
 	}
 
-	cfClient := tasks.GetCloudformationClient(
+	acctID, cfClient := tasks.GetCloudformationClient(
 		c.GlobalString("profile"),
 		region,
 	)
@@ -42,6 +42,16 @@ func PrintEvents(c *cli.Context) {
 			),
 			"https://www.kombustion.io/api/cli/#stacks",
 		)
+	}
+
+	if env, ok := manifestFile.Environments[environment]; ok {
+		if !env.IsWhitelistedAccount(acctID) {
+			printer.Fatal(
+				fmt.Errorf("Account %s is not allowed for environment %s", acctID, environment),
+				"Use whitelisted account, or add account to environment accounts in kombustion.yaml",
+				"",
+			)
+		}
 	}
 
 	stackName = cloudformation.GetStackName(

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -84,7 +84,7 @@ func Upsert(c *cli.Context) {
 		}
 	}
 
-	cfClient := tasks.GetCloudformationClient(
+	acctID, cfClient := tasks.GetCloudformationClient(
 		c.GlobalString("profile"),
 		region,
 	)
@@ -99,6 +99,16 @@ func Upsert(c *cli.Context) {
 	}
 
 	environment := c.String("environment")
+
+	if env, ok := manifestFile.Environments[environment]; ok {
+		if !env.IsWhitelistedAccount(acctID) {
+			printer.Fatal(
+				fmt.Errorf("Account %s is not allowed for environment %s", acctID, environment),
+				"Use whitelisted account, or add account to environment accounts in kombustion.yaml",
+				"",
+			)
+		}
+	}
 
 	tags := manifestFile.Tags
 	if tags == nil {


### PR DESCRIPTION
Check whether the aws account we've connected to matches an account
listed against the environment in kombustion.yaml (if any).

Fixes #89 