### PR TITLE
Load lock from working directory

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/KablamoOSS/go-cli-printer"
@@ -22,7 +21,7 @@ var (
 func FindAndLoadManifest() *Manifest {
 	if loadedManifest == nil {
 		once.Do(func() {
-			path, err := filepath.Abs(filepath.Dir(os.Args[0]))
+			path, err := os.Getwd()
 			if err != nil {
 				printer.Fatal(
 					err,
@@ -46,7 +45,7 @@ func FindAndLoadManifest() *Manifest {
 
 // CheckManifestExists to determine if there is a manifest in the current dir
 func CheckManifestExists() bool {
-	path, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	path, err := os.Getwd()
 	if err != nil {
 		return false
 	}

--- a/internal/plugins/lock/load.go
+++ b/internal/plugins/lock/load.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/yaml"

--- a/internal/plugins/lock/load.go
+++ b/internal/plugins/lock/load.go
@@ -15,7 +15,7 @@ import (
 func FindAndLoadLock() (lock *Lock) {
 	var err error
 
-	path, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	path, err := os.Getwd()
 	if err != nil {
 		printer.Fatal(
 			err,


### PR DESCRIPTION
Previous implementation loaded lock file relative to `kombustion` binary
path - which happened to fall back to current directory if `kombustion`
was called without a qualified path.