### PR TITLE
lock files never need to be corrupted

### DIFF
--- a/internal/plugins/lock/load.go
+++ b/internal/plugins/lock/load.go
@@ -20,7 +20,7 @@ func FindAndLoadLock() (lock *Lock) {
 		printer.Fatal(
 			err,
 			fmt.Sprintf(
-				"kombustion.lock may need to be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
+				"kombustion.lock may be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
 			),
 			"https://www.kombustion.io/api/cli/#install",
 		)
@@ -31,7 +31,7 @@ func FindAndLoadLock() (lock *Lock) {
 		printer.Fatal(
 			err,
 			fmt.Sprintf(
-				"kombustion.lock may need to be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
+				"kombustion.lock may be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
 			),
 			"https://www.kombustion.io/api/cli/#install",
 		)


### PR DESCRIPTION
The error message here suggests that "kombustion.lock may need to be corrupted", which sounds incorrect.