### PR TITLE
remove erroneous Sprintf()s

### DIFF
--- a/internal/cloudformation/tasks/auth.go
+++ b/internal/cloudformation/tasks/auth.go
@@ -21,9 +21,7 @@ func GetCloudformationClient(profile string, region string) (string, *cloudforma
 	if region == "" {
 		printer.Fatal(
 			fmt.Errorf("No region has been set"),
-			fmt.Sprintf(
-				"Pass a region in via the cli with `--region us-east-1` or set a default `region` in kombustion.yaml",
-			),
+			"Pass a region in via the cli with `--region us-east-1` or set a default `region` in kombustion.yaml",
 			"http://kombustion.io/manifest/#region",
 		)
 	}
@@ -43,7 +41,7 @@ func GetCloudformationClient(profile string, region string) (string, *cloudforma
 	if err != nil {
 		printer.Fatal(
 			err,
-			fmt.Sprintf("Check that you have configured valid AWS credentials"),
+			"Check that you have configured valid AWS credentials",
 			"",
 		)
 	}

--- a/internal/cloudformation/tasks/util.go
+++ b/internal/cloudformation/tasks/util.go
@@ -37,7 +37,7 @@ func checkErrorDeletePoll(err error) {
 			os.Exit(0)
 		} else if strings.Contains(err.Error(), "Stack with id") && strings.Contains(err.Error(), "does not exist") {
 			printer.SubStep(
-				fmt.Sprintf("Success: Deleted Stack"),
+				"Success: Deleted Stack",
 				1,
 				true,
 				true,

--- a/internal/core/update.go
+++ b/internal/core/update.go
@@ -39,7 +39,7 @@ func Update(currentVersion string, noPrompt bool) {
 
 		if *latestRelease.TagName == currentVersion {
 			printer.SubStep(
-				fmt.Sprintf("You have the current version."),
+				"You have the current version.",
 				1,
 				true,
 				true,
@@ -71,14 +71,14 @@ func Update(currentVersion string, noPrompt bool) {
 			downloadRelease(downloadURL)
 
 			printer.SubStep(
-				fmt.Sprintf("Update successful."),
+				"Update successful.",
 				1,
 				true,
 				true,
 			)
 		} else {
 			printer.SubStep(
-				fmt.Sprintf("No update performed."),
+				"No update performed.",
 				1,
 				true,
 				true,
@@ -87,7 +87,7 @@ func Update(currentVersion string, noPrompt bool) {
 		}
 	} else {
 		printer.SubStep(
-			fmt.Sprintf("No updates found."),
+			"No updates found.",
 			1,
 			true,
 			true,
@@ -202,7 +202,7 @@ func extractRelease(url, fileName string) (string, error) {
 
 	extracter := GetExtracter(url)
 	if extracter == nil {
-		return "", fmt.Errorf(fmt.Sprintf("Unable to extract: %s", fileName))
+		return "", fmt.Errorf("Unable to extract: %s", fileName)
 	}
 	err := extracter.Open(fileName, destination)
 	if err != nil {

--- a/internal/plugins/extract.go
+++ b/internal/plugins/extract.go
@@ -22,9 +22,7 @@ func ExtractParsersFromPlugins(
 				if _, ok := parsers[pluginKey]; ok { // Check for duplicates
 					printer.Fatal(
 						fmt.Errorf("Plugin `%s` tried to load resource `%s` but it already exists", plugin.Config.Name, pluginKey),
-						fmt.Sprintf(
-							"You can add a `Alias` to this plugin in kombustion.yaml to resolve this.",
-						),
+						"You can add a `Alias` to this plugin in kombustion.yaml to resolve this.",
 						"https://www.kombustion.io/api/manifest/#alias-optional",
 					)
 				} else {

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -227,7 +227,7 @@ func extractPlugin(pluginName string, operatingSystem string, architecture strin
 	destination := getLocalPluginDir(pluginName, operatingSystem, architecture, version)
 	extracter := core.GetExtracter(fileName)
 	if extracter == nil {
-		return extractedFilePath, fmt.Errorf(fmt.Sprintf("Unable to extract: %s", fileName))
+		return extractedFilePath, fmt.Errorf("Unable to extract: %s", fileName)
 	}
 	err = extracter.Open(fileName, destination)
 	var found bool

--- a/internal/plugins/load.go
+++ b/internal/plugins/load.go
@@ -32,9 +32,7 @@ func LoadPlugins(manifestFile *manifest.Manifest, lockFile *lock.Lock) (loadedPl
 			} else {
 				printer.Fatal(
 					fmt.Errorf("Plugin `%s` is not installed, but is included in kombustion.yaml", manifestPlugin.Name),
-					fmt.Sprintf(
-						"Run `kombustion install` to fix.",
-					),
+					"Run `kombustion install` to fix.",
 					"",
 				)
 			}
@@ -73,17 +71,13 @@ func loadPlugin(
 		if isDevPlugin {
 			printer.Fatal(
 				fmt.Errorf("Plugin `%s` could not be found", pluginPath),
-				fmt.Sprintf(
-					"Check the path you provided with --load-plugin is correct.",
-				),
+				"Check the path you provided with --load-plugin is correct.",
 				"https://www.kombustion.io/api/cli/#load-plugin",
 			)
 		}
 		printer.Fatal(
 			fmt.Errorf("Plugin `%s` is not installed, but is included in kombustion.lock", manifestPlugin.Name),
-			fmt.Sprintf(
-				"Run `kombustion install` to fix.",
-			),
+			"Run `kombustion install` to fix.",
 			"",
 		)
 	}
@@ -97,9 +91,7 @@ func loadPlugin(
 	if err != nil {
 		printer.Fatal(
 			fmt.Errorf("Plugin `%s` could not be loaded, this is likely an issue with the plugin", manifestPlugin.Name),
-			fmt.Sprintf(
-				"Try your command again, but if it fails file an issue with the plugin author.",
-			),
+			"Try your command again, but if it fails file an issue with the plugin author.",
 			"",
 		)
 	}

--- a/internal/plugins/lock/load.go
+++ b/internal/plugins/lock/load.go
@@ -1,7 +1,6 @@
 package lock
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 

--- a/internal/plugins/lock/load.go
+++ b/internal/plugins/lock/load.go
@@ -18,9 +18,7 @@ func FindAndLoadLock() (lock *Lock) {
 	if err != nil {
 		printer.Fatal(
 			err,
-			fmt.Sprintf(
-				"kombustion.lock may be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
-			),
+			"kombustion.lock may be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
 			"https://www.kombustion.io/api/cli/#install",
 		)
 	}
@@ -29,9 +27,7 @@ func FindAndLoadLock() (lock *Lock) {
 	if err != nil {
 		printer.Fatal(
 			err,
-			fmt.Sprintf(
-				"kombustion.lock may be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
-			),
+			"kombustion.lock may be corrupted and needs to be rebuilt. Run `kombustion install` to fix this.",
 			"https://www.kombustion.io/api/cli/#install",
 		)
 	}

--- a/internal/tasks/delete.go
+++ b/internal/tasks/delete.go
@@ -25,9 +25,7 @@ func Delete(c *cli.Context) {
 	if fileName == "" {
 		printer.Fatal(
 			fmt.Errorf("Can't upsert file, no source template provided"),
-			fmt.Sprintf(
-				"Add the path to the source template file you want to generate like: `kombustion upsert template.yaml`.",
-			),
+			"Add the path to the source template file you want to generate like: `kombustion upsert template.yaml`.",
 			"https://www.kombustion.io/api/manifest/",
 		)
 	}

--- a/internal/tasks/events.go
+++ b/internal/tasks/events.go
@@ -37,9 +37,7 @@ func PrintEvents(c *cli.Context) {
 	if fileName == "" {
 		printer.Fatal(
 			fmt.Errorf("Can't find stack, no source template provided"),
-			fmt.Sprintf(
-				"Add the path to the source template file, or provide use --stack-name",
-			),
+			"Add the path to the source template file, or provide use --stack-name",
 			"https://www.kombustion.io/api/cli/#stacks",
 		)
 	}

--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -52,9 +52,7 @@ func Generate(c *cli.Context) {
 	if fileName == "" {
 		printer.Fatal(
 			fmt.Errorf("Can't generate file, no source template provided"),
-			fmt.Sprintf(
-				"Add the path to the source template file you want to generate like: `kombustion generate template.yaml`.",
-			),
+			"Add the path to the source template file you want to generate like: `kombustion generate template.yaml`.",
 			"https://www.kombustion.io/api/cli/#generate",
 		)
 	}
@@ -100,9 +98,7 @@ func readParamsFile(file string) (params map[string]string) {
 	if err != nil {
 		printer.Fatal(
 			fmt.Errorf("Couldn't read params file: %v", err),
-			fmt.Sprintf(
-				"Check the file exists, and your user has read permissions",
-			),
+			"Check the file exists, and your user has read permissions",
 			"",
 		)
 	}
@@ -111,9 +107,7 @@ func readParamsFile(file string) (params map[string]string) {
 	if err = json.Unmarshal(body, &cfParams); err != nil {
 		printer.Fatal(
 			fmt.Errorf("Couldn't unmarshal params file: %v", err),
-			fmt.Sprintf(
-				"Check the file is valid JSON, in the standard AWS cli format",
-			),
+			"Check the file is valid JSON, in the standard AWS cli format",
 			"https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Parameter.html",
 		)
 	}

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -58,9 +58,7 @@ func Upsert(c *cli.Context) {
 	if fileName == "" {
 		printer.Fatal(
 			fmt.Errorf("Can't upsert file, no source template provided"),
-			fmt.Sprintf(
-				"Add the path to the source template file you want to generate like: `kombustion upsert template.yaml`.",
-			),
+			"Add the path to the source template file you want to generate like: `kombustion upsert template.yaml`.",
 			"https://www.kombustion.io/api/cli/#upsert",
 		)
 	}


### PR DESCRIPTION
remove a number of `fmt.Sprintf` calls that aren't actually doing any
formatting, or are redundantly used as parameters to fmt.Errorf