### PR TITLE
Generate manifest params

### DIFF
--- a/internal/cloudformation/parameters_test.go
+++ b/internal/cloudformation/parameters_test.go
@@ -28,9 +28,9 @@ func TestResolveEnvironmentParameters(t *testing.T) {
 			name:        "Returns map of env vars",
 			environment: "development",
 			manifest: manifest.Manifest{
-				Name:               "TestManifestWithEnvironment",
-				Plugins:            nil,
-				Architectures:      []string(nil),
+				Name:                   "TestManifestWithEnvironment",
+				Plugins:                nil,
+				Architectures:          []string(nil),
 				GenerateDefaultOutputs: false,
 				Environments: map[string]manifest.Environment{
 					"development": {
@@ -55,9 +55,9 @@ func TestResolveEnvironmentParameters(t *testing.T) {
 			name:        "Returns emtpy map",
 			environment: "production",
 			manifest: manifest.Manifest{
-				Name:               "TestManifestWithEnvironment",
-				Plugins:            nil,
-				Architectures:      []string(nil),
+				Name:                   "TestManifestWithEnvironment",
+				Plugins:                nil,
+				Architectures:          []string(nil),
 				GenerateDefaultOutputs: false,
 				Environments: map[string]manifest.Environment{
 					"development": {
@@ -93,8 +93,8 @@ func TestResolveEnvironmentParameters(t *testing.T) {
 
 func TestResolveParameters(t *testing.T) {
 	type input struct {
-		envName string
-		cliParams map[string]string
+		envName      string
+		cliParams    map[string]string
 		cfYaml       YamlCloudformation
 		cfClient     *awsCF.CloudFormation
 		manifestFile *manifest.Manifest
@@ -109,7 +109,7 @@ func TestResolveParameters(t *testing.T) {
 			name: "Dev",
 			input: input{
 				envName: "development",
-				cliParams: map[string]string {
+				cliParams: map[string]string{
 					"parameterOneName": "parameterOneValue",
 					"parameterTwoName": "8654238642489624862",
 				},
@@ -129,9 +129,9 @@ func TestResolveParameters(t *testing.T) {
 					Outputs:    types.TemplateObject{},
 				},
 				manifestFile: &manifest.Manifest{
-					Name:               "TestManifestWithEnvironment",
-					Plugins:            nil,
-					Architectures:      []string(nil),
+					Name:                   "TestManifestWithEnvironment",
+					Plugins:                nil,
+					Architectures:          []string(nil),
 					GenerateDefaultOutputs: false,
 					Environments: map[string]manifest.Environment{
 						"development": {
@@ -226,9 +226,9 @@ func TestResolveParametersS3(t *testing.T) {
 					return context
 				}(),
 				manifestFile: &manifest.Manifest{
-					Name:               "TestManifestWithEnvironment",
-					Plugins:            nil,
-					Architectures:      []string(nil),
+					Name:                   "TestManifestWithEnvironment",
+					Plugins:                nil,
+					Architectures:          []string(nil),
 					GenerateDefaultOutputs: false,
 					Environments: map[string]manifest.Environment{
 						"development": {

--- a/internal/cloudformation/template_parsers_test.go
+++ b/internal/cloudformation/template_parsers_test.go
@@ -56,7 +56,7 @@ func TestGenerateYamlTemplate(t *testing.T) {
 		{
 			input: GenerateParams{
 				ObjectStore: objectStore,
-				Filename: "test.yaml",
+				Filename:    "test.yaml",
 			},
 			output: YamlCloudformation{
 				AWSTemplateFormatVersion: "2010-09-09",
@@ -124,7 +124,7 @@ func TestGenerateYamlTemplate(t *testing.T) {
 		},
 		{
 			input: GenerateParams{
-				ObjectStore: objectStore,
+				ObjectStore:            objectStore,
 				Filename:               "test.yaml",
 				GenerateDefaultOutputs: true,
 			},

--- a/internal/manifest/init.go
+++ b/internal/manifest/init.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/KablamoOSS/kombustion/internal/core"
 	printer "github.com/KablamoOSS/go-cli-printer"
+	"github.com/KablamoOSS/kombustion/internal/core"
 	"gopkg.in/AlecAivazis/survey.v1"
 )
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -7,7 +7,6 @@ import (
 	yaml "github.com/KablamoOSS/yaml"
 )
 
-
 func CheckManifestExists(objectStore core.ObjectStore) bool {
 	data, err := GetManifestObject(objectStore)
 	if err != nil {
@@ -15,7 +14,6 @@ func CheckManifestExists(objectStore core.ObjectStore) bool {
 	}
 	return data != nil
 }
-
 
 func GetManifestObject(objectStore core.ObjectStore, path ...string) (*Manifest, error) {
 	var manifest Manifest

--- a/internal/plugins/lock/write.go
+++ b/internal/plugins/lock/write.go
@@ -2,8 +2,8 @@ package lock
 
 import (
 	printer "github.com/KablamoOSS/go-cli-printer"
-	"github.com/KablamoOSS/kombustion/internal/core"
 	"github.com/KablamoOSS/kombustion/config"
+	"github.com/KablamoOSS/kombustion/internal/core"
 	"github.com/KablamoOSS/yaml"
 )
 

--- a/internal/tasks/delete.go
+++ b/internal/tasks/delete.go
@@ -5,9 +5,9 @@ import (
 
 	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/config"
-	"github.com/KablamoOSS/kombustion/internal/core"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation/tasks"
+	"github.com/KablamoOSS/kombustion/internal/core"
 	"github.com/KablamoOSS/kombustion/internal/manifest"
 	"github.com/urfave/cli"
 )

--- a/internal/tasks/events.go
+++ b/internal/tasks/events.go
@@ -5,9 +5,9 @@ import (
 
 	printer "github.com/KablamoOSS/go-cli-printer"
 	"github.com/KablamoOSS/kombustion/config"
-	"github.com/KablamoOSS/kombustion/internal/core"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation"
 	"github.com/KablamoOSS/kombustion/internal/cloudformation/tasks"
+	"github.com/KablamoOSS/kombustion/internal/core"
 	"github.com/KablamoOSS/kombustion/internal/manifest"
 	"github.com/urfave/cli"
 )

--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -88,20 +88,11 @@ func generate(
 	devPluginPath string,
 	outputDirectory string,
 	outputParameters bool,
-	env string,
+	envName string,
 	generateDefaultOutputs bool,
 ) {
 	printer.Step("Generate template")
 	printer.Progress("Kombusting")
-
-	paramMap := make(map[string]string)
-	if paramsPath != "" {
-		paramMap = readParamsObject(objectStore, paramsPath)
-	}
-
-	for key, value := range cliParams {
-		paramMap[key] = value
-	}
 
 	lockFile, err := lock.GetLockObject(objectStore, "kombustion.lock")
 	if err != nil {
@@ -122,6 +113,24 @@ func generate(
 		)
 	}
 
+	paramMap := make(map[string]string)
+
+	if env, ok := manifestFile.Environments[envName]; ok {
+		for key, value := range env.Parameters {
+			paramMap[key] = value
+		}
+	}
+
+	if paramsPath != "" {
+		for key, value := range readParamsObject(objectStore, paramsPath) {
+			paramMap[key] = value
+		}
+	}
+
+	for key, value := range cliParams {
+		paramMap[key] = value
+	}
+
 	// load all plugins
 	loadedPlugins := plugins.LoadPlugins(manifestFile, lockFile)
 
@@ -136,7 +145,7 @@ func generate(
 		Filename:               templatePath,
 		Directory:              outputDirectory,
 		WriteParams:            outputParameters,
-		Env:                    env,
+		Env:                    envName,
 		ParamMap:               paramMap,
 		Plugins:                loadedPlugins,
 		GenerateDefaultOutputs: generateDefaultOutputs || manifestFile.GenerateDefaultOutputs,

--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -64,7 +64,7 @@ func Generate(c *cli.Context) {
 	outputDirectory := c.String("output-directory")
 	inputParameters := c.String("read-parameters")
 	outputParameters := c.Bool("write-parameters")
-	env := c.String("env")
+	env := c.String("environment")
 	generateDefaultOutputs := c.Bool("generate-default-outputs")
 
 	generate(

--- a/internal/tasks/generate_test.go
+++ b/internal/tasks/generate_test.go
@@ -11,9 +11,9 @@ var sampleKombYaml = `---
 Name: Kombustion
 Region: ""
 Environments:
-  development:
+  ci:
     Parameters:
-      Environment: development
+      BucketName: fooBucket
 GenerateDefaultOutputs: false
 Tags: {}
 `
@@ -61,6 +61,13 @@ Resources:
         Value: 123
 `
 
+var expectedParameterOutput = `[
+  {
+    "ParameterKey": "BucketName",
+    "ParameterValue": "fooBucket"
+  }
+]`
+
 func TestSimpleGenerate(t *testing.T) {
 	objectStore := coretest.NewMockObjectStore()
 	objectStore.Put([]byte(sampleKombYaml), "kombustion.yaml")
@@ -71,19 +78,22 @@ func TestSimpleGenerate(t *testing.T) {
 		t,
 		func() {
 			generate(
-				objectStore,
-				"test.yaml",
-				map[string]string{},
-				"",
-				"",
-				"compiled",
-				true,
-				"ci",
-				false,
+				objectStore,         // objectStore
+				"test.yaml",         // templatePath
+				map[string]string{}, // cliParams
+				"",                  // paramsPath
+				"",                  // devPluginPath
+				"compiled",          // outputDirectory
+				true,                // ouputParameters
+				"ci",                // envName
+				false,               // generateDefaultOutputs
 			)
 		},
 	)
 
 	output, _ := objectStore.Get("compiled", "test.yaml")
 	assert.Equal(t, expectedOutput, string(output))
+
+	output, _ = objectStore.Get("compiled", "test-params.json")
+	assert.Equal(t, expectedParameterOutput, string(output))
 }

--- a/internal/tasks/install.go
+++ b/internal/tasks/install.go
@@ -21,7 +21,6 @@ func installPlugins(objectStore core.ObjectStore) {
 	printer.Step("Install plugins")
 	printer.Progress("Kombusting")
 
-
 	lockFile, err := lock.GetLockObject(objectStore, "kombustion.lock")
 	if err != nil {
 		printer.Fatal(err, config.ErrorHelpInfo, "")

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -186,8 +186,8 @@ func upsert(
 	// Template generation parameters
 	generateParams := cloudformation.GenerateParams{
 		ObjectStore: objectStore,
-		Filename: templatePath,
-		Env:      env,
+		Filename:    templatePath,
+		Env:         env,
 		GenerateDefaultOutputs: generateDefaultOutputs || manifestFile.GenerateDefaultOutputs,
 		ParamMap:               paramMap,
 		Plugins:                loadedPlugins,

--- a/internal/tasks/upsert.go
+++ b/internal/tasks/upsert.go
@@ -75,7 +75,7 @@ func Upsert(c *cli.Context) {
 	region := c.String("region")
 	devPluginPath := c.GlobalString("load-plugin")
 	inputParameters := c.String("read-parameters")
-	env := c.String("env")
+	env := c.String("environment")
 	generateDefaultOutputs := c.Bool("generate-default-outputs")
 	capabilities := getCapabilities(c)
 	confirm := c.Bool("confirm")


### PR DESCRIPTION
Ensure that `--write-params` on `kombustion generate` includes parameters from the manifest environment.